### PR TITLE
Dump uploaded csv data to log in handler

### DIFF
--- a/course_manager/views.py
+++ b/course_manager/views.py
@@ -46,8 +46,7 @@ def route_section_data(request):
     
     # Parse section data from the front end
     logger.debug(route_section_data.__name__)
-    request_body = json.loads(request.body.decode("utf-8"))
-    logger.debug(request_body)
+    logger.info(request.POST['data'])
     course_id = request.session['course_id']
 
     return HttpResponse(json.dumps({'resp': True, 'course_id': course_id}))


### PR DESCRIPTION
Accessing the uploaded csv data via request.body.decode() throws an exception, accessing it via request.POST['data'] instead seems to work.